### PR TITLE
Link dav1d executable with custom IA2 glibc dynamic linker

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -97,4 +97,4 @@ option('ia2_permissive_mode',
 option('ia2_libc_compartment',
     type: 'boolean',
     value: false,
-    description: 'Use the custom IA2 glibc dynamic linker (requires IA2_LIBC_COMPARTMENT)')
+    description: 'Use the custom IA2 glibc dynamic linker (requires libia2 built with IA2_LIBC_COMPARTMENT)')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -93,3 +93,8 @@ option('ia2_permissive_mode',
     type: 'boolean',
     value: false,
     description: 'Enable IA2\'s permissive mode')
+
+option('ia2_libc_compartment',
+    type: 'boolean',
+    value: false,
+    description: 'Use the custom IA2 glibc dynamic linker (requires IA2_LIBC_COMPARTMENT)')

--- a/rewrite.py
+++ b/rewrite.py
@@ -425,6 +425,7 @@ def main(
             *ia2_path_args,
             *meson_cross_args,
             "-Dia2_enable=true",
+            "-Dia2_libc_compartment=true",
             f"-Dia2_permissive_mode={permissive_mode}",
             f"--buildtype={dav1d_meson_build_type.value}",
         ]()

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -78,6 +78,12 @@ if ia2_path != ''
             '-Wl,-wrap,asprintf',
             '-Wl,-wrap,vasprintf',
         ]
+        if get_option('ia2_libc_compartment')
+            link_args += [
+                '-Wl,--dynamic-linker=' + join_paths(ia2_build_path, 'runtime/libia2/ld-linux-x86-64.so.2'),
+                '-Wl,-rpath,' + join_paths(ia2_build_path, 'runtime/libia2'),
+            ]
+        endif
     endif
 endif
 


### PR DESCRIPTION
When `IA2_LIBC_COMPARTMENT` is enabled, the IA2 build produces a custom glibc `ld.so` that reserves pkey 1 for libc's own writable data via `pkey_alloc` at startup. `liblibia2.a` is compiled with `IA2_LDSO_PKEY=1`, so `ia2_set_up_tags()` assumes pkey 1 is already taken and expects its first `pkey_alloc` call to return 2. Without the custom `ld.so`, pkey 1 is never allocated, so `pkey_alloc` returns 1 instead, and `ia2_set_up_tags()` aborts.

This adds `--dynamic-linker` and `-rpath` link flags to the dav1d executable so it uses the custom IA2-aware `ld.so` and finds the matching `libc.so.6`. This mirrors the INTERFACE link options that IA2's cmake sets on the `libia2` target for cmake-based consumers.

The flags are gated behind a new `ia2_libc_compartment` meson option so they are only applied when the custom `ld.so` actually exists. `rewrite.py` passes `-Dia2_libc_compartment=true` automatically since it builds IA2 with `IA2_LIBC_COMPARTMENT=ON`.